### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@smartcontractkit/devrel


### PR DESCRIPTION
Adding CODEOWNERS in .github/CODEOWNERS with DevRel ownership